### PR TITLE
Pod not on Node error

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -155,7 +155,6 @@ func GenerateReports(promconn promv1.API, ts promv1.Range, log logr.Logger) erro
 
 	// yearMonth is used in filenames
 	yearMonth := ts.Start.Format("200601") // this corresponds to YYYYMM format
-	emptyNodeRow := NewNodeRow(ts)
 
 	log.Info("querying for node metrics")
 	nodeResults, err := getQueryResults(querier, nodeQueries)
@@ -213,7 +212,7 @@ func GenerateReports(promconn promv1.API, ts promv1.Range, log logr.Logger) erro
 			if row, ok := nodeRows[node.(string)]; ok {
 				usage.NodeRow = *row.(*NodeRow)
 			} else {
-				usage.NodeRow = emptyNodeRow
+				usage.NodeRow = NewNodeRow(ts)
 			}
 		}
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -155,6 +155,7 @@ func GenerateReports(promconn promv1.API, ts promv1.Range, log logr.Logger) erro
 
 	// yearMonth is used in filenames
 	yearMonth := ts.Start.Format("200601") // this corresponds to YYYYMM format
+	emptyNodeRow := NewNodeRow(ts)
 
 	log.Info("querying for node metrics")
 	nodeResults, err := getQueryResults(querier, nodeQueries)
@@ -209,7 +210,11 @@ func GenerateReports(promconn promv1.API, ts promv1.Range, log logr.Logger) erro
 		}
 		if node, ok := val["node"]; ok {
 			// Add the Node usage to the pod.
-			usage.NodeRow = nodeRows[node.(string)].(*NodeRow)
+			if row, ok := nodeRows[node.(string)]; ok {
+				usage.NodeRow = *row.(*NodeRow)
+			} else {
+				usage.NodeRow = emptyNodeRow
+			}
 		}
 	}
 	if err := writeResults(podFilePrefix, yearMonth, "pod", podRows); err != nil {

--- a/collector/types.go
+++ b/collector/types.go
@@ -105,7 +105,7 @@ func (row NamespaceRow) String() string {
 
 type NodeRow struct {
 	*DateTimes
-	Node                          string
+	Node                          string `json:"node"`
 	NodeCapacityCPUCores          string `json:"node-capacity-cpu-cores"`
 	ModeCapacityCPUCoreSeconds    string `json:"node-capacity-cpu-core-seconds"`
 	NodeCapacityMemoryBytes       string `json:"node-capacity-memory-bytes"`
@@ -171,9 +171,9 @@ func (row NodeRow) String() string {
 
 type PodRow struct {
 	*DateTimes
-	*NodeRow
-	Namespace                   string
-	Pod                         string
+	NodeRow
+	Namespace                   string `json:"namespace"`
+	Pod                         string `json:"pod"`
 	PodUsageCPUCoreSeconds      string `json:"pod-usage-cpu-core-seconds"`
 	PodRequestCPUCoreSeconds    string `json:"pod-request-cpu-core-seconds"`
 	PodLimitCPUCoreSeconds      string `json:"pod-limit-cpu-core-seconds"`


### PR DESCRIPTION
This PR fixes an error that arises when a Pod is not associated with a Node:
```
2020-10-19T15:08:24.556-0400    INFO    controllers.CostManagement      writing node results to file    {"costmanagement": "writeResults", "filename": "/tmp/cost-mgmt-operator-reports/data/cm-openshift-node-labels-lookback-202010.csv", "data set": "node"}
E1019 15:08:24.568296   71545 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x21c47e0), concrete:(*runtime._type)(nil), asserted:(*runtime._type)(0x21d0ea0), missingMethod:""} (interface conversion: collector.CSVStruct is nil, not *collector.NodeRow)
```
