### PR TITLE
add service certificate

### DIFF
--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -51,7 +51,7 @@ var (
 	thanosRouteName     = "thanos-querier"
 	tokenRegex          = "default-token-*"
 
-	certFile = "/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt"
+	certFile = "/var/run/configmaps/trusted-ca-bundle/service-ca.crt"
 )
 
 // PrometheusConfig provides the configuration options to set up a Prometheus connections from a URL.

--- a/config/samples/trusted_ca_certmap.yaml
+++ b/config/samples/trusted_ca_certmap.yaml
@@ -8,5 +8,6 @@
       name: trusted-ca-bundle
       annotations:
         release.openshift.io/create-only: "true"
+        service.beta.openshift.io/inject-cabundle: "true"
       labels:
         config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
This PR adds a service certificate which enables TLS verification for the prometheus query requests.

This cert only works for the internal route (i.e. `https://thanos-querier.openshift-monitoring.svc:9091`). Otherwise, we will still get the `x509: certificate signed by unknown authority` error when attempting prometheus queries.