### PR TITLE
time fixes

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -42,6 +42,8 @@ import (
 var (
 	logger logr.Logger
 
+	dataPath = "/tmp/cost-mgmt-operator-reports/data/"
+
 	podFilePrefix       = "cm-openshift-pod-usage-"
 	volFilePrefix       = "cm-openshift-storage-usage-"
 	nodeFilePrefix      = "cm-openshift-node-usage-"

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -42,11 +42,10 @@ import (
 var (
 	logger logr.Logger
 
-	dataPath            = "/tmp/cost-mgmt-operator-reports/data/"
-	podFilePrefix       = "cm-openshift-usage-lookback-"
-	volFilePrefix       = "cm-openshift-persistentvolumeclaim-lookback-"
-	nodeFilePrefix      = "cm-openshift-node-labels-lookback-"
-	namespaceFilePrefix = "cm-openshift-namespace-labels-lookback-"
+	podFilePrefix       = "cm-openshift-pod-usage-"
+	volFilePrefix       = "cm-openshift-storage-usage-"
+	nodeFilePrefix      = "cm-openshift-node-usage-"
+	namespaceFilePrefix = "cm-openshift-namespace-usage-"
 
 	statusTimeFormat = "2006-01-02 15:04:05"
 )

--- a/controllers/costmanagement_controller.go
+++ b/controllers/costmanagement_controller.go
@@ -528,8 +528,7 @@ func (r *CostManagementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	if err != nil {
 		log.Error(err, "failed to get prometheus connection")
 	} else {
-		utcTime := metav1.Now().UTC()
-		t := metav1.Time{Time: utcTime}
+		t := metav1.Now()
 		timeRange := promv1.Range{
 			Start: time.Date(t.Year(), t.Month(), t.Day(), t.Hour()-1, 0, 0, 0, t.Location()),
 			End:   time.Date(t.Year(), t.Month(), t.Day(), t.Hour()-1, 59, 59, 0, t.Location()),


### PR DESCRIPTION
- access the metav1.Time.Time. <- This cleans up a lot of logic around converting a metav1.Time variable to time.Time.
- rename base report prefixes