### PR TITLE
Prometheus query/report fixes

### DIFF
--- a/collector/queries.go
+++ b/collector/queries.go
@@ -137,7 +137,7 @@ var (
 		Query{
 			Name:        "persistentvolumeclaim-labels",
 			QueryString: "kube_persistentvolumeclaim_labels * on(persistentvolumeclaim) group_left(volumename) kube_persistentvolumeclaim_info",
-			MetricKey:   &StaticFields{MetricLabel: []model.LabelName{"persistentvolumeclaim"}},
+			MetricKey:   &StaticFields{MetricLabel: []model.LabelName{"namespace", "persistentvolumeclaim"}},
 			MetricKeyRegex: &RegexFields{
 				MetricRegex: []string{"label_*"},
 				LabelMap:    []string{"persistentvolumeclaim_labels"}},

--- a/collector/types.go
+++ b/collector/types.go
@@ -128,11 +128,11 @@ func (NodeRow) CSVheader(w io.Writer) error {
 		"interval_start",
 		"interval_end",
 		"node",
-		"node_capacity_cpu_cores",
-		"node_capacity_cpu_core_seconds",
-		"node_capacity_memory_bytes",
-		"node_capacity_memory_byte_seconds",
-		"resource_id",
+		// "node_capacity_cpu_cores",  // if Node and Pod reports are ever separated, these lines can be uncommented
+		// "node_capacity_cpu_core_seconds",
+		// "node_capacity_memory_bytes",
+		// "node_capacity_memory_byte_seconds",
+		// "resource_id",
 		"node_labels"}); err != nil {
 		return err
 	}
@@ -156,11 +156,11 @@ func (row NodeRow) RowString() []string {
 		row.IntervalStart,
 		row.IntervalEnd,
 		row.Node,
-		row.NodeCapacityCPUCores,
-		row.ModeCapacityCPUCoreSeconds,
-		row.NodeCapacityMemoryBytes,
-		row.NodeCapacityMemoryByteSeconds,
-		row.ResourceID,
+		// row.NodeCapacityCPUCores,
+		// row.ModeCapacityCPUCoreSeconds,
+		// row.NodeCapacityMemoryBytes,
+		// row.NodeCapacityMemoryByteSeconds,
+		// row.ResourceID,
 		row.NodeLabels,
 	}
 }

--- a/controllers/costmanagement_controller.go
+++ b/controllers/costmanagement_controller.go
@@ -535,7 +535,7 @@ func (r *CostManagementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			End:   time.Date(t.Year(), t.Month(), t.Day(), t.Hour()-1, 59, 59, 0, t.Location()),
 			Step:  time.Minute,
 		}
-		if costConfig.LastQuerySuccessTime.IsZero() || costConfig.LastQuerySuccessTime.Hour() != t.Hour() {
+		if costConfig.LastQuerySuccessTime.IsZero() || costConfig.LastQuerySuccessTime.UTC().Hour() != t.Hour() {
 			cost.Status.Prometheus.LastQueryStartTime = t
 			log.Info("generating reports for range", "start", timeRange.Start, "end", timeRange.End)
 			err = collector.GenerateReports(cost, promConn, timeRange, r.Log)

--- a/controllers/costmanagement_controller.go
+++ b/controllers/costmanagement_controller.go
@@ -554,7 +554,6 @@ func (r *CostManagementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	if err := r.Status().Update(ctx, cost); err != nil {
 		log.Error(err, "failed to update CostManagement Status")
 	}
-	time.Sleep(5 * time.Second) // Give the update some time to complete.
 
 	// Requeue for processing after 5 minutes
 	return ctrl.Result{RequeueAfter: time.Minute * 5}, nil

--- a/controllers/costmanagement_controller.go
+++ b/controllers/costmanagement_controller.go
@@ -528,7 +528,8 @@ func (r *CostManagementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	if err != nil {
 		log.Error(err, "failed to get prometheus connection")
 	} else {
-		t := metav1.Now()
+		timeUTC := metav1.Now().UTC()
+		t := metav1.Time{Time: timeUTC}
 		timeRange := promv1.Range{
 			Start: time.Date(t.Year(), t.Month(), t.Day(), t.Hour()-1, 0, 0, 0, t.Location()),
 			End:   time.Date(t.Year(), t.Month(), t.Day(), t.Hour()-1, 59, 59, 0, t.Location()),
@@ -553,6 +554,7 @@ func (r *CostManagementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	if err := r.Status().Update(ctx, cost); err != nil {
 		log.Error(err, "failed to update CostManagement Status")
 	}
+	time.Sleep(5 * time.Second) // Give the update some time to complete.
 
 	// Requeue for processing after 5 minutes
 	return ctrl.Result{RequeueAfter: time.Minute * 5}, nil


### PR DESCRIPTION
- Make node reports like old reports
- Fix storage query so that namespace is added to PVC. The namespace was missed if the PVC did not have an associated Pod
- Use UTC timezone for queries and reports